### PR TITLE
fix: hide random/manual select buttons if off state

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -341,6 +341,47 @@ const Home: NextPage = () => {
             </h2>
           )}
 
+          {/* manual select button */}
+          {latestLightState?.on_off === 1 && !autoSwitchInterval.active && (
+            <ActionIcon
+              size="xl"
+              radius="xl"
+              variant="outline"
+              style={{
+                color: hslString,
+              }}
+              onClick={() => {
+                setManuallySelecting((prev) => !prev);
+              }}
+            >
+              {manuallySelecting ? (
+                <BiArrowBack size="1.7rem" title="go back" />
+              ) : (
+                <MdColorLens size="1.7rem" title="select color" />
+              )}
+            </ActionIcon>
+          )}
+
+          {/* manual select color picker */}
+          {manuallySelecting && (
+            <ChromePicker
+              color={{
+                h: Number(latestLightState?.hue),
+                s: Number(latestLightState?.saturation) / 100,
+                l: Number(latestLightState?.brightness) / 100,
+              }}
+              onChangeComplete={(color: ColorResult) => {
+                changeColor({
+                  hue: Math.floor(color.hsl.h),
+                  saturation: Math.floor(color.hsl.s * 100),
+                  brightness: Math.floor(color.hsl.l * 100),
+                  on_off: 1,
+                }).catch((e) => console.error(e));
+              }}
+              disableAlpha
+            />
+          )}
+
           {/* random button */}
           {latestLightState?.on_off === 1 && !autoSwitchInterval.active && (
             <ActionIcon
@@ -429,47 +470,6 @@ const Home: NextPage = () => {
                 roundCaps
               />
             </>
-          )}
-
-          {/* manual select button */}
-          {latestLightState?.on_off === 1 && !autoSwitchInterval.active && (
-            <ActionIcon
-              size="xl"
-              radius="xl"
-              variant="outline"
-              style={{
-                color: hslString,
-              }}
-              onClick={() => {
-                setManuallySelecting((prev) => !prev);
-              }}
-            >
-              {manuallySelecting ? (
-                <BiArrowBack size="1.7rem" title="go back" />
-              ) : (
-                <MdColorLens size="1.7rem" title="select color" />
-              )}
-            </ActionIcon>
-          )}
-
-          {/* manual select color picker */}
-          {manuallySelecting && (
-            <ChromePicker
-              color={{
-                h: Number(latestLightState?.hue),
-                s: Number(latestLightState?.saturation) / 100,
-                l: Number(latestLightState?.brightness) / 100,
-              }}
-              onChangeComplete={(color: ColorResult) => {
-                changeColor({
-                  hue: Math.floor(color.hsl.h),
-                  saturation: Math.floor(color.hsl.s * 100),
-                  brightness: Math.floor(color.hsl.l * 100),
-                  on_off: 1,
-                }).catch((e) => console.error(e));
-              }}
-              disableAlpha
-            />
           )}
 
           {/* on/off button */}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -342,7 +342,7 @@ const Home: NextPage = () => {
           )}
 
           {/* random button */}
-          {lamp && !autoSwitchInterval.active && (
+          {latestLightState?.on_off === 1 && !autoSwitchInterval.active && (
             <ActionIcon
               size="xl"
               radius="xl"
@@ -432,7 +432,7 @@ const Home: NextPage = () => {
           )}
 
           {/* manual select button */}
-          {lamp && !autoSwitchInterval.active && (
+          {latestLightState?.on_off === 1 && !autoSwitchInterval.active && (
             <ActionIcon
               size="xl"
               radius="xl"


### PR DESCRIPTION
Turns out that if its current state is OFF (`on_off = 0`), no matter what color we send to the lamp, it'll just light up to the color it previously had. So to avoid unwanted results I've restricted these buttons (random and manual select ones) to when the current state is ON (`on_off = 1`).

Also, the buttons have been moved to te first two positions 